### PR TITLE
Dynamic versioning within working directory via 'git describe'

### DIFF
--- a/pycam/__init__.py
+++ b/pycam/__init__.py
@@ -18,7 +18,8 @@ You should have received a copy of the GNU General Public License
 along with PyCAM.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-VERSION = "0.6.1-dev"
+from pycam.version import VERSION  # noqa F401
+
 
 FILTER_CONFIG = (("Config files", "*.conf"),)
 HELP_WIKI_URL = "http://sourceforge.net/apps/mediawiki/pycam/index.php?title=%s"

--- a/pycam/version.py
+++ b/pycam/version.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+
+
+def get_git_describe():
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    proc = subprocess.Popen(["git", "describe", "--tags"], stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, cwd=repo_dir)
+    stdout, stderr = proc.communicate()
+    if proc.returncode == 0:
+        return stdout.strip().lstrip(b'v') or None
+    else:
+        return None
+
+
+VERSION = get_git_describe()


### PR DESCRIPTION
Use `git-describe` within a git working directory for determining the current version.
Use a hardcoded version string for releases.