### PR TITLE
Deb version - variant 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,16 @@ Thumbs.db
 .*.swp
 
 man/pycam.1
+# windows build remainder
+scripts/pycam-loader.py
 
 # Generated mkdocs files go into the site directory
 site/
+
+# debian packaging
+debian/debhelper-build-stamp
+debian/files
+debian/pycam/
+debian/pycam.debhelper.log
+debian/pycam.*.debhelper
+debian/pycam.substvars

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ Thumbs.db
 *~
 .*.swp
 
+man/pycam.1
+
 # Generated mkdocs files go into the site directory
 site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script:
   - python setup.py sdist
   - ./scripts/pycam --help
   - ./scripts/pycam --version
+  - dpkg-buildpackage -us -uc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
   - make check-style
   - python setup.py sdist
   - ./scripts/pycam --help
+  - ./scripts/pycam --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install: true
 
 script:
   - export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  - debian/rules prep-source
   - make check-style
   - python setup.py sdist
   - ./scripts/pycam --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
   - "2.6"
   - "2.7"
 
+git:
+    depth: 10000
+
 before_install: ./scripts/travis-install-build-deps.sh
 
 install: true

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,20 @@ RM = rm -f
 	check-style pylint-relaxed pylint-strict test \
 	update-version update-deb-changelog
 
+info:
+	@echo "Available targets:"
+	@echo "    build"
+	@echo "    clean"
+	@echo "    dist"
+	@echo "    docs"
+	@echo "    man"
+	@echo "    upload-docs"
+	@echo
+	@echo "Style checks:"
+	@echo "    check-style"
+	@echo "    pylint-relaxed"
+	@echo "    pylint-strict"
+
 build: man update-version
 	$(PYTHON_EXE) setup.py build
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ WEBSITE_UPLOAD_LOCATION ?= web.sourceforge.net:/home/project-web/pycam/htdocs
 ARCHIVE_DIR := $(shell pwd)/$(ARCHIVE_DIR_RELATIVE)
 RM = rm -f
 
-.PHONY: zip tgz win32 clean dist git_export upload create_archive_dir man check-style test \
+.PHONY: zip tgz win32 clean dist git_export create_archive_dir man check-style test \
 	pylint-relaxed pylint-strict docs upload-docs
 
 dist: zip tgz win32
@@ -71,15 +71,6 @@ win32: create_archive_dir man git_export
 	# this is a binary release
 	cd "$(EXPORT_DIR)"; $(PYTHON_EXE) setup.py bdist_wininst --user-access-control force \
 		--dist-dir "$(ARCHIVE_DIR)" $(DISTUTILS_PLAT_NAME)
-
-upload:
-	svn cp "$(SVN_REPO_BASE)" "$(REPO_TAGS)/release-$(VERSION)" -m "tag release $(VERSION)"
-	svn import "$(ARCHIVE_DIR)/$(EXPORT_ZIP)" "$(REPO_TAGS)/archives/$(EXPORT_ZIP)" \
-		-m "added released zip file for version $(VERSION)"
-	svn import "$(ARCHIVE_DIR)/$(EXPORT_TGZ)" "$(REPO_TAGS)/archives/$(EXPORT_TGZ)" \
-		-m "added released tgz file for version $(VERSION)"
-	svn import "$(ARCHIVE_DIR)/$(EXPORT_WIN32)" "$(REPO_TAGS)/archives/$(EXPORT_WIN32)" \
-		-m "added released win32 installer for version $(VERSION)"
 
 test: check-style
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(DIST_WIN32): $(DIST_DIR) build
 update-deb-changelog:
 	@# retrieve the log of all commits since the latest release and add it to the deb changelog
 	if ! grep -qFw "$(VERSION)" debian/changelog; then \
-		git log --pretty=format:%s v$(shell dpkg-parsechangelog -S version).. | \
+		git log --pretty=format:%s v$(shell dpkg-parsechangelog | sed --quiet -re 's/Version: (.*)/\1/ p').. | \
 			DEBFULLNAME="PyCAM Builder" DEBEMAIL="builder@pycam.org" \
 			xargs -r -d '\n' -n 1 -- debchange --newversion "$(subst -,.,$(VERSION))"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ RM = rm -f
 	check-style pylint-relaxed pylint-strict test \
 	update-version update-deb-changelog
 
+build: man update-version
+	$(PYTHON_EXE) setup.py build
+
 archive: tgz win32
 	@# we can/should remove the version file in order to avoid a stale local version
 	@$(RM) "$(VERSION_FILE)"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # from the subversion repository.
 
 # use something like "VERSION=0.2 make" to override the VERSION on the command line
-VERSION ?= $(shell sed -n "s/^.*[\t ]*VERSION[\t ]*=[\t ]*[\"']\([^\"']*\)[\"'].*/\1/gp" pycam/__init__.py)
+VERSION = $(shell python -c 'import pycam; print(pycam.VERSION)')
+VERSION_FILE = pycam/Version.py
 REPO_TAGS ?= https://pycam.svn.sourceforge.net/svnroot/pycam/tags
 ARCHIVE_DIR_RELATIVE ?= release-archives
 PYTHON_EXE ?= python
@@ -29,7 +30,7 @@ ARCHIVE_DIR := $(shell pwd)/$(ARCHIVE_DIR_RELATIVE)
 RM = rm -f
 
 .PHONY: zip tgz win32 clean dist git_export create_archive_dir man check-style test \
-	pylint-relaxed pylint-strict docs upload-docs
+	pylint-relaxed pylint-strict docs upload-docs update-version
 
 dist: zip tgz win32
 	@# we can/should remove the version file in order to avoid a stale local version
@@ -38,6 +39,7 @@ dist: zip tgz win32
 clean:
 	@$(RM) -r build
 	@$(RM) -r "$(MKDOCS_EXPORT_DIR)"
+	@$(RM) "$(VERSION_FILE)"
 	$(MAKE) -C man clean
 
 man:
@@ -56,6 +58,9 @@ win32: create_archive_dir man
 	# this is a binary release
 	$(PYTHON_EXE) setup.py bdist_wininst --user-access-control force \
 		--dist-dir "$(ARCHIVE_DIR)" $(DISTUTILS_PLAT_NAME)
+
+update-version:
+	@echo 'VERSION = "$(VERSION)"' >| "$(VERSION_FILE)"
 
 test: check-style
 

--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,14 @@ include /usr/share/dpkg/default.mk
 %:
 	dh $@ --with python2
 
+# This target updates pycam/Version.py and debian/changelog with current
+# information from git.  It's intended to be run before generating the
+# debian source package.
+prep-source:
+	$(MAKE) update-version
+	$(MAKE) update-deb-changelog
+	rm -f pycam/*.pyc
+
 override_dh_auto_build:
 	$(MAKE) -C man
 	python setup.py build

--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,10 @@ prep-source:
 	$(MAKE) update-deb-changelog
 	rm -f pycam/*.pyc
 
+override_dh_auto_clean:
+	$(MAKE) clean
+	debian/rules prep-source
+
 override_dh_auto_build:
 	$(MAKE) -C man
 	python setup.py build

--- a/pycam/.gitignore
+++ b/pycam/.gitignore
@@ -1,0 +1,1 @@
+Version.py

--- a/pycam/__init__.py
+++ b/pycam/__init__.py
@@ -18,7 +18,70 @@ You should have received a copy of the GNU General Public License
 along with PyCAM.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-VERSION = "0.6.2-dev"
+
+import os
+import subprocess
+
+
+try:
+    from Version import VERSION
+
+except ImportError:
+    # Failed to import Version.py, we must be running out of a git
+    # checkout, so generate the version info from git tags.
+
+    #
+    # These variables should only be changed by the release manager when
+    # creating a new stable release branch.
+    #
+    # In master:
+    #     * 'parent_branch' stays set to 'master'
+    #     * 'tag_glob' is changed to the glob for the next set of releases.
+    #
+    # In the new stable branch:
+    #     * 'parent_branch' is set to the name of the new stable branch.
+    #     * 'tag_glob' stays set to the glob for release tags on this branch.
+    #
+    parent_branch = "master"
+    tag_glob = "v0.*"
+
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+    try:
+        current_branch = subprocess.check_output(['git', 'rev-parse',
+                                                  '--abbrev-ref',
+                                                  'HEAD'],
+                                                 cwd=repo_dir)
+        current_branch = current_branch.strip()
+
+        git_describe = subprocess.check_output(["git", "describe",
+                                                "--always", "--dirty",
+                                                "--tags", "--match",
+                                                tag_glob], cwd=repo_dir)
+        # remove the "v" prefix
+        git_describe = git_describe.strip().lstrip("v")
+
+        if current_branch == parent_branch:
+            # We're on master or on a stable/release branch, so the
+            # version number is just the 'git describe' output.
+            VERSION = git_describe
+
+        else:
+            # We're on a temporary branch, so make a version number that
+            # sorts as *older than* nearby release versions.
+            parts = git_describe.split('-')
+            parts[0] = parts[0] + '~' + current_branch
+            VERSION = '-'.join(parts)
+
+        # No matter how we made the version string, replace every "-"
+        # with ".", because that's what Debian version numbers expect.
+        # https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
+        VERSION = VERSION.replace('-', '.')
+
+    except subprocess.CalledProcessError:
+        # No pycam/Version.py and git failed to give us a version number, give up.
+        VERSION = "0.0-unknown"
+
 
 FILTER_CONFIG = (("Config files", "*.conf"),)
 DOC_BASE_URL = "http://pycam.sourceforge.net/%s/"

--- a/release_info.txt
+++ b/release_info.txt
@@ -39,3 +39,49 @@
  - create a new release tag for the bug tracker:
    https://sourceforge.net/tracker/admin/index.php?group_id=237831&atid=1104176&add_group=1
 
+
+# Version numbers
+
+If the user runs pycam out of a git working directory without
+taking any special action with respect to versioning,
+pycam determines the version dynamically each time it's
+invoked. The algorithm is at the top of pycam/__init__.py.
+
+When building Debian packages of pycam, the build system uses that code to
+produce pycam/Version.py, which just sets the VERSION variable according
+to the git working directory that the package was built from.
+
+Version numbers are determined like this:
+
+* Some commits correspond to actual releases, these are indicated by
+  special tags (like our "v0.5.1" tag, "v0.6.0", etc). The version
+  number of a commit with a release tag is just the release tag itself,
+  of course.
+
+* The version number of a commit without a release tag is constructed in a
+  "git describe"-like way: the most recent release tag, followed by the
+  number of commits since then, followed by the SHA of the current commit,
+  followed by "dirty" if there are uncommited, non-ignored changes in
+  the git working directory.
+
+However, there's a complication needed to handle multiple branches. The
+versioning code considers two kinds of branches:
+
+* Long-lived branches like master (for current development) and stable
+  release branches (we don't have any yet, but imagine a "v0" branch,
+  "v1", etc). These branches are where the release tags live. We
+  want un-tagged commits in these branches to have the simple kind of
+  version number described above (tag, commits since tag, SHA). Example:
+  v0.6.1.345.gabc123 ("345 commits after v0.6.1").
+
+* Short-lived temporary branches (for new features, bug fixes, etc). These
+  branches have more complicated version numbers. Version numbers here
+  should show which long-lived branch this temporary branch came from
+  (by having a version number from that long-lived branch), but should
+  be clearly differentiated from versions actually from that long-lived
+  branch, and should include the name of the short-lived branch. Example:
+  v0.6.1~deb.version.sumpfralle.86.g6789cc3 ("deb-version-sumpfralle
+  branch, 86 commits after v0.6.1"). The "~" tilde character there
+  is deliberate: it sorts as "older than" in Debian version numbers,
+  so debs from short-lived branches will not replace debs from stable
+  release branches by mistake.


### PR DESCRIPTION
This pull request is based on #31.

Its main purpose is the simplification of the version handling with fewer files. See especially:
* 5498f228b9e1f2b04c6bb3409170cdacca7c4f89
* d7582c0d975b32e674b856e4d1879e1b44b13003

Additionally the setuptools-oriented targets (source release and pypi release) now work with this versioning, too (the previous `git_export` approach prevented this before).
Furthermore obsolete targets were removed.