### PR TITLE
Update help links and documentation

### DIFF
--- a/docs/process-settings.md
+++ b/docs/process-settings.md
@@ -17,7 +17,7 @@ roughly cleaning the material if it is deeper than the maximum
 penetration depth of your current tool. The *Step Down* value specifies
 the maximum height of each layer.
 
-### Contour (polygon)
+### Waterline/Contour (polygon)
 
 ![Screenshot of 3D view showing Contour (polygon) strategy](img/process-strategy-contour-polygon.png)
 
@@ -40,7 +40,9 @@ requires more processing time.
 The contour-&gt;follow strategy is quite new (v0.4) and thus should be
 considered experimental.
 
-### Surface
+This strategy is not (yet) available from the GUI.
+
+### Surfacing
 
 ![Screenshot of 3D view showing surface strategy](img/process-strategy-surface.png)
 
@@ -74,7 +76,7 @@ Specify if the toolpath lines should move along the X or the Y axis.
 Milling style
 -------------
 
-### Conventional
+### Conventional / up
 
 In conventional milling style the cutter (rotating clockwise) moves with
 the material on its left side. Thus the force applied to tool is quite
@@ -83,7 +85,7 @@ style. This should be mainly used for older machines or hard material.
 
 ![Diagram of conventional milling style](img/process-milling-conventional.png)
 
-### Climb
+### Climb / down
 
 In climb milling style the cutter (rotating clockwise) moves with the
 material on its right side. Thus the force applied to the tool rises
@@ -101,12 +103,6 @@ height.
 
 Parameters
 ----------
-
-### Safety height
-
-The safety height is the absolute z-level that is considered to be safe
-for rapid movements. This should be clearly above the highest point of
-your model.
 
 ### Overlap \[%\]
 
@@ -172,3 +168,12 @@ The following conditions must be fulfilled for any pocketed area:
     inside of the surrounding polygon
 
 Pocketing is done with 20% overlap (not configurable).
+
+### Safety height
+
+The safety height is the absolute z-level that is considered to be safe
+for rapid movements. This should be clearly above the highest point of
+your model.
+
+This parameter is set after generating the toolpath, and can be found for each 
+toolpath under Settings/Preferences.

--- a/docs/task-settings.md
+++ b/docs/task-settings.md
@@ -1,0 +1,3 @@
+Task settings
+=============
+Toolpaths are generated in tasks, which are formed by a combination of a tool, a process, bounds, and zero or more collision models. This way it is possible to make different combinations for different steps in the milling process.

--- a/docs/tool-types.md
+++ b/docs/tool-types.md
@@ -1,0 +1,4 @@
+Tool types
+==========
+Pycam support three tool shapes: Flat bottom (cylindrical), ball nose (spherical), and bull nose (toroidal).
+In addition to the tool shape the feedrate and spindle speed are also configured per tool.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,8 +28,10 @@ pages:
   - 3D View: 3d-view.md
   - Model Transformations: model-transformations.md
   - Engrave Fonts: engrave-fonts.md
+  - Tool Types: tool-types.md
   - Process Settings: process-settings.md
   - Bounding Box: bounding-box.md
+  - Task Settings: task-settings.md
 - Advanced Usage:
   - Keyboard Shortcuts: keyboard-shortcuts.md
   - Command-line Examples: cli-examples.md

--- a/pycam/Gui/common.py
+++ b/pycam/Gui/common.py
@@ -44,7 +44,7 @@ DEPENDENCY_DESCRIPTION = {
            ""),
 }
 
-REQUIREMENTS_LINK = "http://sf.net/apps/mediawiki/pycam/?title=Requirements"
+REQUIREMENTS_LINK = "http://pycam.sourceforge.net/requirements"
 
 # Usually the windows registry "HKEY_LOCAL_MACHINE/SOFTWARE/Gtk+/Path" contains
 # something like: C:\Programs\Common files\GTK

--- a/pycam/Importers/DXFImporter.py
+++ b/pycam/Importers/DXFImporter.py
@@ -925,7 +925,7 @@ def import_model(filename, color_as_height=False, fonts_cache=None, callback=Non
                  len(lines), len(model.get_polygons()))
         return model
     else:
-        link = "http://sf.net/apps/mediawiki/pycam/?title=SupportedFormats"
+        link = "http://pycam.sourceforge.net/supported-formats"
         log.error('DXFImporter: No supported elements found in DXF file!\n'
                   '<a href="%s">Read PyCAM\'s modeling hints.</a>', link)
         return None

--- a/pycam/Utils/threading.py
+++ b/pycam/Utils/threading.py
@@ -117,8 +117,8 @@ def is_multiprocessing_enabled():
 
 
 def is_server_mode_available():
-    # the following definition should be kept in sync with the wiki:
-    # http://sf.net/apps/mediawiki/pycam/?title=Parallel_Processing_on_different_Platforms
+    # the following definition should be kept in sync with the documentation in
+    # docs/parallel-processing.md
     return is_multiprocessing_available()
 
 
@@ -198,8 +198,7 @@ def init_threading(number_of_processes=None, enable_server=False, remote=None, r
         # due to "pickle errors". How to reproduce: run the standalone binary
         # with "--enable-server --server-auth-key foo".
         feature_matrix_text = ("Take a look at the wiki for a matrix of platforms and available "
-                               "features: http://sf.net/apps/mediawiki/pycam/?title="
-                               "Parallel_Processing_on_different_Platforms")
+                               "features: http://pycam.sourceforge.net/parallel-processing")
         if enable_server:
             log.warn("Unable to enable server mode with your current setup.\n%s",
                      feature_matrix_text)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     download_url="http://sourceforge.net/projects/pycam/files",
     keywords=["3-axis", "cnc", "cam", "toolpath", "machining", "g-code"],
     long_description="""IMPORTANT NOTE: Please read the list of requirements:
-http://sourceforge.net/apps/mediawiki/pycam/index.php?title=Requirements
+http://pycam.sourceforge.net/requirements
 Basically you will need Python, GTK and OpenGL.
 
 Windows: select Python 2.5 in the following dialog.

--- a/share/ui/bounds.ui
+++ b/share/ui/bounds.ui
@@ -201,7 +201,7 @@
                     <property name="receives_default">True</property>
                     <property name="relief">none</property>
                     <property name="use_stock">True</property>
-                    <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=BoundsSettings</property>
+                    <property name="uri">http://pycam.sourceforge.net/bounding-box</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/share/ui/fonts.ui
+++ b/share/ui/fonts.ui
@@ -235,7 +235,7 @@
                 <property name="receives_default">True</property>
                 <property name="relief">none</property>
                 <property name="use_stock">True</property>
-                <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=EngraveFonts</property>
+                <property name="uri">http://pycam.sourceforge.net/engrave-fonts</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/share/ui/models.ui
+++ b/share/ui/models.ui
@@ -148,7 +148,7 @@
                     <property name="receives_default">True</property>
                     <property name="relief">none</property>
                     <property name="use_stock">True</property>
-                    <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=ModelTransformations</property>
+                    <property name="uri">http://pycam.sourceforge.net/model-transformations</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/share/ui/opengl.ui
+++ b/share/ui/opengl.ui
@@ -350,7 +350,7 @@
         <property name="relief">none</property>
         <property name="use_stock">True</property>
         <property name="xalign">1</property>
-        <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=3D_View</property>
+        <property name="uri">http://pycam.sourceforge.net/3d-view</property>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/share/ui/parallel_processing.ui
+++ b/share/ui/parallel_processing.ui
@@ -229,7 +229,7 @@ Please read the description of the Server Mode (linked below) to understand the 
                     <property name="receives_default">True</property>
                     <property name="relief">none</property>
                     <property name="xalign">0</property>
-                    <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=ServerMode</property>
+                    <property name="uri">http://pycam.sourceforge.net/server-mode</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -471,7 +471,7 @@ You will need remote workers.&lt;/span&gt;</property>
 You are probably using the Windows standalone executable.
 Instead you could use the PyCAM installer package along with the all-in-one installer of all dependencies.
 
-See the &lt;a href="http://sf.net/apps/mediawiki/pycam/?title=Parallel_Processing_on_different_Platforms"&gt;platform feature matrix&lt;/a&gt; for details.</property>
+See the &lt;a href="http://pycam.sourceforge.net/parallel-processing"&gt;platform feature matrix&lt;/a&gt; for details.</property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
                   </object>
@@ -677,7 +677,7 @@ See the &lt;a href="http://sf.net/apps/mediawiki/pycam/?title=Parallel_Processin
                                     <property name="receives_default">True</property>
                                     <property name="relief">none</property>
                                     <property name="use_stock">True</property>
-                                    <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=ServerMode</property>
+                                    <property name="uri">http://pycam.sourceforge.net/server-mode</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">2</property>

--- a/share/ui/processes.ui
+++ b/share/ui/processes.ui
@@ -150,7 +150,7 @@
                 <property name="receives_default">True</property>
                 <property name="relief">none</property>
                 <property name="use_stock">True</property>
-                <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=ProcessSettings</property>
+                <property name="uri">http://pycam.sourceforge.net/process-settings</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/share/ui/pycam-project.ui
+++ b/share/ui/pycam-project.ui
@@ -181,7 +181,7 @@
                             <property name="has_tooltip">True</property>
                             <property name="tooltip_text" translatable="yes">Inkscape is a vector drawing program. It can be used to convert 2D SVG files into DXF contour models.</property>
                             <property name="xalign">0</property>
-                            <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=Requirements#Inkscape</property>
+                            <property name="uri">http://inkscape.org</property>
                           </object>
                           <packing>
                             <property name="x_options">GTK_FILL</property>
@@ -197,7 +197,7 @@
                             <property name="tooltip_text" translatable="yes">pstoedit is a postscript conversion tool. It can be used to convert 2D SVG files into DXF contour models.</property>
                             <property name="relief">none</property>
                             <property name="xalign">0</property>
-                            <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=Requirements#Inkscape</property>
+                            <property name="uri">http://www.pstoedit.net/pstoedit</property>
                           </object>
                           <packing>
                             <property name="top_attach">1</property>
@@ -302,7 +302,7 @@
                             <property name="relief">none</property>
                             <property name="use_stock">True</property>
                             <property name="xalign">1</property>
-                            <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=Requirements#Optional_external_programs</property>
+                            <property name="uri">http://pycam.sourceforge.net/requirements/#optional-external-programs</property>
                           </object>
                           <packing>
                             <property name="right_attach">4</property>

--- a/share/ui/tasks.ui
+++ b/share/ui/tasks.ui
@@ -180,7 +180,7 @@
                 <property name="receives_default">True</property>
                 <property name="relief">none</property>
                 <property name="use_stock">True</property>
-                <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=TaskSettings</property>
+                <property name="uri">http://pycam.sourceforge.net/task-settings</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/share/ui/tools.ui
+++ b/share/ui/tools.ui
@@ -170,7 +170,7 @@
                 <property name="receives_default">True</property>
                 <property name="relief">none</property>
                 <property name="use_stock">True</property>
-                <property name="uri">http://sourceforge.net/apps/mediawiki/pycam/index.php?title=ToolTypes</property>
+                <property name="uri">http://pycam.sourceforge.net/tool-types</property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
All the help links inside the program are dead, this pull request updates them to point to the generated documentation hosted on pycam.sourceforge.net

Also some documentation is updated to be more in line with the GUI.

Good to see life in this project again! Thanks for the work!