### PR TITLE
fix flake8 warnings

### DIFF
--- a/pycam/Plugins/ModelSupportGrid.py
+++ b/pycam/Plugins/ModelSupportGrid.py
@@ -86,7 +86,8 @@ class ModelSupportGrid(pycam.Plugins.PluginBase):
             self.grid_adjustment_value = self.gui.get_object("SupportGridPositionManualAdjustment")
             self.grid_adjustment_value_control = self.gui.get_object(
                 "SupportGridPositionManualShiftControl")
-            # self.grid_adjustment_value_control.set_update_policy(self._gtk.UPDATE_DISCONTINUOUS) FIXME
+            # FIXME
+            # self.grid_adjustment_value_control.set_update_policy(self._gtk.UPDATE_DISCONTINUOUS)
             self._gtk_handlers.extend((
                 (self.grid_adjustment_value_control, "move-slider",
                  self.update_support_grid_manual_adjust),

--- a/pycam/Plugins/OpenGLWindow.py
+++ b/pycam/Plugins/OpenGLWindow.py
@@ -23,7 +23,7 @@ import math
 # careful import
 try:
     # disable opengl visualization
-    import disable_opengl_visualization_due_to_missing_opengl_support_for_gtk3
+    raise ImportError()
     # import gtk.gtkgl
     import OpenGL.GL as GL
     import OpenGL.GLU as GLU

--- a/scripts/pycam
+++ b/scripts/pycam
@@ -29,7 +29,6 @@ from optparse import OptionParser
 import os
 import socket
 import sys
-import time
 import warnings
 
 # we need the multiprocessing exception for remote connections
@@ -49,16 +48,13 @@ except ImportError:
                                                      os.pardir)))
     from pycam import VERSION
 
-from pycam import GenericError
 import pycam.Exporters.GCodeExporter
-from pycam.Geometry import Box3D, Point3D
 import pycam.Gui.common as GuiCommon
 import pycam.Gui.Settings
 import pycam.Gui.Console
 import pycam.Importers.TestModel
 import pycam.Importers
 import pycam.Plugins
-from pycam.Toolpath import Bounds, Toolpath
 import pycam.Utils
 from pycam.Utils.events import get_event_handler
 import pycam.Utils.log
@@ -226,13 +222,6 @@ There is NO WARRANTY, to the extent permitted by law.""".format(VERSION)
         log.error("The remote server rejected your authentication key: %s", err_msg)
         return EXIT_CODES["connection_error"]
 
-    # initialize the progress bar
-    progress_styles = {"none": pycam.Gui.Console.ConsoleProgressBar.STYLE_NONE,
-                       "text": pycam.Gui.Console.ConsoleProgressBar.STYLE_TEXT,
-                       "bar": pycam.Gui.Console.ConsoleProgressBar.STYLE_BAR,
-                       "dot": pycam.Gui.Console.ConsoleProgressBar.STYLE_DOT}
-    progress_bar = pycam.Gui.Console.ConsoleProgressBar(sys.stdout, progress_styles[opts.progress])
-
     show_gui()
 
 
@@ -250,11 +239,6 @@ def main_func():
                              "Most parameters are useful only for batch mode."),
         epilog="PyCAM website: https://github.com/SebKuzminsky/pycam")
     group_general = parser.add_option_group("General options")
-    group_export = parser.add_option_group(
-        "Export formats", ("Export the resulting toolpath or meta-data in various formats. These "
-                           "options trigger the non-interactive mode. Thus the GUI is disabled."))
-    group_external_programs = parser.add_option_group(
-        "External programs", "Some optional external programs are used for format conversions.")
     # general options
     group_general.add_option(
         "", "--unit", dest="unit_size", default="mm", action="store", type="choice",


### PR DESCRIPTION
This fixes all the flake8 warnings in master (eg https://travis-ci.org/SebKuzminsky/pycam/jobs/278814925) and lets the Travis job progress a little further.

I'm not sure if it's right long-term to remove all the unused code.  For example, `group_export` should probably be added back in and populated with the available export formats.