### PR TITLE
restore pycam.Geometry.Line.get_line_length()

### DIFF
--- a/pycam/Geometry/Line.py
+++ b/pycam/Geometry/Line.py
@@ -131,6 +131,11 @@ class Line(IDGenerator, TransformableContainer):
     def point_with_length_multiply(self, l):
         return padd(self.p1, pmul(self.dir, l*self.len))
 
+    def get_length_line(self, length):
+        """ return a line with the same direction and the specified length
+        """
+        return Line(self.p1, padd(self.p1, pmul(self.dir, length)))
+
     def closest_point(self, p):
         v = self.dir
         if v is None:


### PR DESCRIPTION
NOTE: This PR is for the new "stable/0.6" branch, because it addresses a bug in that branch. If this PR is accepted, I will merge the bug fix into the master branch so it gets fixed there too.

This function was removed in commit 52b80196 "removed unused
code (reported by 'vulture')", but it is actually used by
pycam.Geometry.Polygon.is_connectable().  vulture just missed it.

You can see the problem that arises when this function is missing by
following this recipe:

    1. Start pycam.
    2. Delete the default model.
    3. Import a 2d model.
    4. Create a new Tool (all default).
    5. Create a new Process, Engraving, select the 2d model from step 3,
       enable radius compensation.
    6. Create a new Bounds (all default).
    7. Create a new Task (all default)>
    8. Click Generate Toolpath.

Before this commit (but after 52b80196), pycam fails to produce a
sensible toolpath.  After this commit, the correct toolpath is generated.