### PR TITLE
make sure Travis jobs know the git branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install: ./scripts/travis-install-build-deps.sh
 install: true
 
 script:
+  - export BRANCH=$(if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then echo ${TRAVIS_BRANCH}; else echo ${TRAVIS_BRANCH}-${TRAVIS_PULL_REQUEST_BRANCH}-pr${TRAVIS_PULL_REQUEST}; fi)
+  - git branch -D ${BRANCH} || true
+  - git checkout -b ${BRANCH} ${TRAVIS_COMMIT}
   - export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   - make test
   - python setup.py sdist


### PR DESCRIPTION
We want to use the git branch name to help figure out the pycam version
number, but travis-ci's git handling means our job runs with a detached
HEAD (ie, with no branch set).

This commit figures out the branch name from the travis job's environment
variables, and manipulates git to set the branch name appropriately.

Branch names are constructed like this:

* When building a push, use the name of the branch that was pushed to
  (of course).

* Github presents each PR as a new merge commit in the
  destination branch, merging in the new branch.  In this case,
  use "${DEST_BRANCH}-${NEW_BRANCH}-pr${PR_NUMBER}", for example
  "stable/0.6-0.6-travis-branch-name-pr87".