### PR TITLE
Updating the Dockerfile for Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM debian:9
 
 COPY . /root/pycam
 
-RUN apt-get update && apt-get install -y python \
-    python-gi \
+RUN apt-get update && apt-get install -y python3 \
+    python3-gi \
+    python3-opengl \
+    python3-yaml \
     gir1.2-gtk-3.0
 
 CMD [ "/root/pycam/pycam/run_gui.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:9
 
-COPY . /root/pycam
+WORKDIR /root/pycam
+
+COPY . .
 
 RUN apt-get update && apt-get install -y python3 \
     python3-gi \
@@ -8,4 +10,4 @@ RUN apt-get update && apt-get install -y python3 \
     python3-yaml \
     gir1.2-gtk-3.0
 
-CMD [ "/root/pycam/pycam/run_gui.py" ]
+CMD [ "pycam/run_gui.py" ]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,12 +14,13 @@ Install the following packages with your package manager:
 python3
 python3-gi
 python3-opengl
+python3-yaml
 gir1.2-gtk-3.0
 ```
 
 On a Debian or Ubuntu system, you would just type the following:
 ```bash
-sudo apt install python3-gi python3-opengl gir1.2-gtk-3.0
+sudo apt install python3-gi python3-opengl python3-yaml gir1.2-gtk-3.0
 ```
 Please note that you need to enable the `universe` repository in Ubuntu.
 
@@ -27,14 +28,17 @@ Please note that you need to enable the `universe` repository in Ubuntu.
 
 If you have difficulty with the installation, you can run the application from Docker.
 
+The `docker run` command will mount your personal Documents folder to `/root/Documents` so that you
+can access your files.
+
 ```bash
-sudo docker pull pycam/pycam  # downloads the latest image
+sudo docker build -t pycam/pycam .
 sudo docker run -it \
     -v ~/Documents:/root/Documents \
     -v ~/.Xauthority:/root/.Xauthority \
     -e DISPLAY \
     --net=host \
-    pycam/run_gui.py
+    pycam/pycam
 ```
 
 ## macOS
@@ -46,7 +50,7 @@ sudo docker run -it \
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
-2\. Install the dependencies (currently only for Python2):
+2\. Install the dependencies (currently only for Python2):  
 TODO: adjust for Python3
 ```bash
 brew install gtk+3 pygobject3
@@ -58,7 +62,7 @@ pip install pygobject enum34
 If you have difficulty with the installation, you can run the application from Docker.
 
 1\. Make sure that Docker is installed, if not, you can install it with Homebrew.
-You will also be needing XQuartz and socat.
+You will also need XQuartz and socat.
 
 ```bash
 brew cask install docker xquartz
@@ -81,13 +85,13 @@ The `docker run` command will mount your personal Documents folder to `/root/Doc
 can access your files.
 
 ```bash
-docker pull pycam/pycam  # downloads the latest image
-IP='<your local ip address>'
+docker build -t pycam/pycam .
+export IP='<your local ip address>'
 docker run -it \
     -v ~/Documents:/root/Documents \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e DISPLAY=$IP:0 \
-    pycam/run_gui.py
+    pycam/pycam
 ```
 
 # Minimal requirements for non-GUI mode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Graphical Interface: `pycam/run_gui.py`
 Scripted Toolpath Processing: `pycam/run_cli.py FLOW_SPECIFICATION_FILE`
 
 
-## Ressources
+## Resources
 
 See the [documentation](http://pycam.sourceforge.net/introduction/) for a short introduction.
 


### PR DESCRIPTION
Also updating the instructions to build a docker image locally, versus downloading it from DockerHub. With this, it will install the most recent version from master and not a potentially outdated one that is currently manually managed. Alternatively, DockerHub can be set to auto-build an image when master is updated, or for new releases. Someone with write access to the repo can set that up; the work here is a fine way to go, though.