### PR TITLE
Attempt to use OpenGL compatibility profile by default.

### DIFF
--- a/pycam/Plugins/__init__.py
+++ b/pycam/Plugins/__init__.py
@@ -36,6 +36,13 @@ def _get_plugin_imports():
     # We do this once for all - in order to centralize and minimize error handling.
     result = {key: None for key in ("gtk", "gdk", "gdkpixbuf", "gdkobject", "gio", "glib",
                                     "GL", "GLU", "GLUT")}
+
+    # By default, Gdk loads the OpenGL 3.2 Core profile. However, PyCAM's rendering
+    # code uses the fixed function pipeline, which was removed in the Core profile.
+    # So we have to resort to this semi-public API to ask Gdk to use a Compatibility
+    # profile instead.
+    os.environ['GDK_GL'] = 'legacy'
+
     try:
         import gi
         gi.require_version('Gtk', '3.0')


### PR DESCRIPTION
PyCAM's rendering code relies on the OpenGL fixed function
pipeline, which was removed from the OpenGL 3.2 Core profile.

Sadly, that is the default version used by Gdk, and the public
API of GLArea and GLContext does not allow switching the profile
or using a version < 3.2, therefore we have to attempt to change
Gdk behaviour through environment variables.

Ironically, setting `GDK_GL=legacy' will usually result in
a more modern OpenGL version being used, e.g. switching from
3.2 Core to 4.6 Compatibility on my machine.