### PR TITLE
 Fixed scaling to work with 2d (dxf/svg) models.

### DIFF
--- a/pycam/workspace/data_models.py
+++ b/pycam/workspace/data_models.py
@@ -920,8 +920,8 @@ class ModelTransformation(BaseDataContainer):
             for key, current_size, target_size in zip(
                     ("scale_x", "scale_y", "scale_z"), model.get_dimensions(), axes):
                 if current_size == 0:
-                    raise InvalidDataError("Model transformation 'scale' does not accept "
-                                           "zero as a target size ({}).".format(key))
+                    kwargs[key] = 1.0
+                    _log.warning('Did not scale axis {} because it has no depth'.format(key))
                 elif target_size is None:
                     kwargs[key] = 1.0
                 else:

--- a/pycam/workspace/data_models.py
+++ b/pycam/workspace/data_models.py
@@ -921,7 +921,7 @@ class ModelTransformation(BaseDataContainer):
                     ("scale_x", "scale_y", "scale_z"), model.get_dimensions(), axes):
                 if current_size == 0:
                     kwargs[key] = 1.0
-                    _log.warning('Did not scale axis {} because it has no depth'.format(key))
+                    _log.warning("Did not scale axis because it has no depth ({})".format(key))
                 elif target_size is None:
                     kwargs[key] = 1.0
                 else:


### PR DESCRIPTION
I had a problem, that I couldn't scale 2d files to a certain size due to "Model transformation 'scale' does not accept zero as a target size"
Fixed it by not resizing an axis at all if axis' size is 0. 

This shouldn't introduce any bugs with 3d models, as it's impossible to fully flatten a 3d model in PyCAM, but any 2d path can be scaled to any size