### PR TITLE
Fixed get_scaled_model function + minor gui fix

### DIFF
--- a/pycam/Plugins/ModelScaling.py
+++ b/pycam/Plugins/ModelScaling.py
@@ -82,7 +82,8 @@ class ModelScaling(pycam.Plugins.PluginBase):
             scale_box.show()
             # scale controls
             axis_control = self.gui.get_object("ScaleDimensionAxis")
-            scale_button = self.gui.get_object("ScaleSelectedAxisButton")
+            scale_selected_button = self.gui.get_object("ScaleSelectedAxisButton")
+            scale_all_button = self.gui.get_object("ScaleAllAxesButton")
             scale_value = self.gui.get_object("ScaleDimensionControl")
             index = axis_control.get_active()
             enable_controls = False
@@ -92,7 +93,8 @@ class ModelScaling(pycam.Plugins.PluginBase):
                 value = dims[index]
                 non_zero_dimensions = [i for i, dim in enumerate(dims) if dim > 0]
                 enable_controls = enable_controls or (index in non_zero_dimensions)
-            scale_button.set_sensitive(enable_controls)
+            scale_selected_button.set_sensitive(enable_controls)
+            scale_all_button.set_sensitive(enable_controls)
             scale_value.set_sensitive(enable_controls)
             scale_value.set_value(value)
 

--- a/pycam/workspace/data_models.py
+++ b/pycam/workspace/data_models.py
@@ -919,11 +919,14 @@ class ModelTransformation(BaseDataContainer):
         elif target == ModelScaleTarget.SIZE:
             for key, current_size, target_size in zip(
                     ("scale_x", "scale_y", "scale_z"), model.get_dimensions(), axes):
-                if current_size == 0:
+                if target_size == 0:
                     raise InvalidDataError("Model transformation 'scale' does not accept "
                                            "zero as a target size ({}).".format(key))
                 elif target_size is None:
                     kwargs[key] = 1.0
+                elif current_size == 0:
+                    kwargs[key] = 1.0
+                    # don't scale axis if it's flat
                 else:
                     kwargs[key] = target_size / current_size
         else:


### PR DESCRIPTION
Ensured scaling to 0 is not possible, and axes with size 0 are ignored.

Also greyed out "Scale All" button if axis' size is 0. (Previously only 
"Scale Selected") was greyed out.
Done this because while an axis with size 0 is selected, pressing "Scale all" automatically scaled all axes to 0.001, which can break models with short segments. (I don't know why, probably their size is being rounded to 0)