### PR TITLE
Improve XDG desktop text and add the X-CNC category

### DIFF
--- a/share/desktop/pycam.desktop
+++ b/share/desktop/pycam.desktop
@@ -1,13 +1,13 @@
 [Desktop Entry]
 Version=1.0
 Name=PyCAM
-GenericName=Toolpath Generator
-Comment=generate GCode for 3-Axis CNC machining
+GenericName=CNC Toolpath Generator
+Comment=Generate GCode for 3-Axis CNC machining.
 Exec=pycam %u
 TryExec=pycam
 Terminal=false
 Type=Application
-Categories=Development;Engineering;Robotics;Education;Science;2DGraphics;VectorGraphics;3DGraphics;
+Categories=Development;Engineering;Robotics;Education;Science;2DGraphics;VectorGraphics;3DGraphics;X-CNC;
 MimeType=application/sla;image/svg+xml;application/postscript;image/vnd.dxf;
 Icon=pycam
 


### PR DESCRIPTION
This improve the visual apperence and content in the desktop menus,
as well as make sure it show up next to LinuxCNC in the CNC submenu
when installed alongside LinuxCNC.