### PR TITLE
Add code and metadata to enforce the use of Python 3.

### DIFF
--- a/pycam/Utils/__init__.py
+++ b/pycam/Utils/__init__.py
@@ -30,6 +30,8 @@ from urllib.request import url2pathname
 # import win32com
 # import win32api
 
+if sys.version_info.major < 3:
+    raise RuntimeError("Only work with Python 3 or later")
 
 # setproctitle is (optionally) imported
 try:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     author_email="devel@sumpfralle.de",
     provides=["pycam"],
     requires=["PyOpenGL", "PyYAML"],
+    python_requires='>=3.0',
     url="http://pycam.sourceforge.net/",
     download_url="http://sourceforge.net/projects/pycam/files",
     keywords=["3-axis", "cnc", "cam", "toolpath", "machining", "g-code"],


### PR DESCRIPTION
Tell setup.py to require python >= 3.0, and throw a RuntimeError
if the sys.version_info.major is below 3.

Fixes #187.