### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ BASE_DIR = os.path.realpath(os.path.abspath(os.path.dirname(__file__)))
 
 setup(
     name="pycam",
-    version=VERSION,
+    version="0.7.0",
     license="GPL v3",
     description="Open Source CAM - Toolpath Generation for 3-Axis CNC machining",
     author="Lars Kruse",


### PR DESCRIPTION
Fixed an issue where strict setuptools version validation, combined with a non-PEP 440 compliant version string, caused `setup.py` to crash outright.